### PR TITLE
Set maildir flags on message filenames

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,8 +800,7 @@ dependencies = [
 [[package]]
 name = "notmuch"
 version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d7ab27cedb5b7464ad261d55ddf6da7f770f56364cec589b3a8d9a1d7d2bf85"
+source = "git+https://github.com/vhdirk/notmuch-rs#a24d8aa9715a47431610af9b3c88400d1896177f"
 dependencies = [
  "from_variants",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ itertools = "0.10.3"
 lazy_static = "1.4.0"
 loe = "0.3.0"
 log = "0.4.16"
-notmuch = "0.7.2"
+notmuch = { git = "https://github.com/vhdirk/notmuch-rs" }
 rayon = "1.5.2"
 regex = "1.5.5"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/src/local.rs
+++ b/src/local.rs
@@ -293,6 +293,8 @@ impl Local {
                 message.add_tag(tag)?;
             }
             message.thaw()?;
+            // XXX make configurable
+            message.tags_to_maildir_flags()?;
         }
         Ok(())
     }


### PR DESCRIPTION
Maildir encodes some message flags into the message filenames, and mail
clients that aren't (fully) notmuch-aware expect to find them there.
notmuch has facilities for renaming message files to get flags matching
those in the notmuch store; this commit hooks all that up.

Closes #8.