### PR TITLE
Refactoring: apply mailboxes & tags, not emails; don't hold notmuch messsage objects

### DIFF
--- a/src/local.rs
+++ b/src/local.rs
@@ -1,5 +1,4 @@
 use crate::jmap;
-use crate::remote;
 use crate::sync::NewEmail;
 use const_format::formatcp;
 use lazy_static::lazy_static;
@@ -260,7 +259,6 @@ impl Email {
 
     pub fn update(
         &self,
-        remote_email: &remote::Email,
         tags: HashSet<&str>,
     ) -> Result<(), notmuch::Error> {
         // Build diffs for tags and apply them.
@@ -277,8 +275,7 @@ impl Email {
             .filter(|&tag| !extant_tags.contains(tag))
             .collect();
         debug!(
-            "Updating local email: {:?}, {:?}, by adding tags: {tags_to_add:?}, removing tags: {tags_to_remove:?}",
-            self, remote_email
+            "Updating local email: {self:?}, by adding tags: {tags_to_add:?}, removing tags: {tags_to_remove:?}"
         );
         for tag in tags_to_remove {
             self.message.remove_tag(tag)?;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -476,8 +476,8 @@ pub fn sync(
                     }
                 }
 
-                local_email
-                    .update(tags)
+                local
+                    .update_email_tags(local_email, tags)
                     .context(UpdateLocalEmailSnafu {})?;
             }
 

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -477,7 +477,7 @@ pub fn sync(
                 }
 
                 local_email
-                    .update(remote_email, tags)
+                    .update(tags)
                     .context(UpdateLocalEmailSnafu {})?;
             }
 


### PR DESCRIPTION
This could be two PRs, one with the first three commits and one with the other two, but they're all moving towards the same goal so here they are all together.

This started with #10, where we learned that we need to be getting the Message object from notmuch to make sure we don't get a stale filename list.

I initially thought to keep a `HashMap<String,notmuch::Message>` inside `struct Local`, but the problem is that all of the sync and update code dealt only with `Email` objects, and the `Local` object wasn't available. As I teased it apart, it became clear to me that `local` and `remote` had too much knowledge of each other's `Email` objects, and that I would be passing a `Local` into `Remote::update`, very odd.

So I peeled all that back and made `local` only deal with messages in the notmuch index and the maildir, and `remote` only deals with the server, with mailboxes and tags as the "intermediate" data ferried between the two.

Its not perfect; I think maybe `remote` could benefit from a similar lift (removing `impl remote::Email`), and as I said in a comment, I think the add-mailboxes-to-tags logic might belong somewhere other than `sync`, and if you look at #10, it does still reach out for the`notmuch::Message` to get the filename list, which suggests `sync` still knows too much. But I think I'm content with this for now because it certainly does remove a lot of coupling.

In the end I didn't actually add that cache of messages because we rarely reuse them and its easy to just look them up. But `local::get_message` could easily be made to keep hold of them internally and loan them out, if that turned out to be a performance bottleneck in the future.