### PR TITLE
Get mail dir path from notmuch

### DIFF
--- a/src/local.rs
+++ b/src/local.rs
@@ -68,8 +68,6 @@ pub struct Local {
     db: Database,
     /// The path to mujmap's maildir/cur.
     pub mail_cur_dir: PathBuf,
-    /// Notmuch search query which searches for all mail in mujmap's maildir.
-    all_mail_query: String,
     /// Flag, whether or not notmuch should add maildir flags to message filenames.
     pub synchronize_maildir_flags: bool,
 }
@@ -105,9 +103,6 @@ impl Local {
 
         debug!("mail dir: {}", canonical_mail_dir_path.to_str().unwrap());
 
-        // Build the query to search for all mail in our maildir.
-        let all_mail_query = "path:**".to_string();
-
         // Ensure the maildir contains the standard cur, new, and tmp dirs.
         let mail_cur_dir = canonical_mail_dir_path.join("cur");
         if !dry_run {
@@ -125,7 +120,6 @@ impl Local {
         Ok(Self {
             db,
             mail_cur_dir,
-            all_mail_query,
             synchronize_maildir_flags,
         })
     }
@@ -141,14 +135,13 @@ impl Local {
 
     /// Return all `Email`s that mujmap owns for this maildir.
     pub fn all_emails(&self) -> Result<HashMap<jmap::Id, Email>> {
-        self.query(&self.all_mail_query)
+        self.query("path:**")
     }
 
     /// Return all `Email`s that mujmap owns which were modified since the given database revision.
     pub fn all_emails_since(&self, last_revision: u64) -> Result<HashMap<jmap::Id, Email>> {
         self.query(&format!(
-            "{} and lastmod:{}..{}",
-            self.all_mail_query,
+            "path:** and lastmod:{}..{}",
             last_revision,
             self.revision()
         ))

--- a/src/local.rs
+++ b/src/local.rs
@@ -14,9 +14,7 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fs;
 use std::io;
-use std::path::Path;
 use std::path::PathBuf;
-use std::path::StripPrefixError;
 
 const ID_PATTERN: &'static str = r"[-A-Za-z0-9_]+";
 const MAIL_PATTERN: &'static str = formatcp!(r"^({})\.({})(?:$|:)", ID_PATTERN, ID_PATTERN);
@@ -80,7 +78,7 @@ impl Local {
     /// Open the local store.
     ///
     /// `mail_dir` *must* be a subdirectory of the notmuch path.
-    pub fn open(mail_dir: impl AsRef<Path>, dry_run: bool) -> Result<Self> {
+    pub fn open(dry_run: bool) -> Result<Self> {
         // Open the notmuch database with default config options.
         let db = Database::open_with_config::<PathBuf, PathBuf>(
             None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,14 +51,14 @@ fn try_main(stdout: &mut StandardStream) -> Result<(), Error> {
         .to_owned();
 
     // Determine working directory and load all data files.
-    let mail_dir = args.path.clone().unwrap_or_else(|| PathBuf::from("."));
+    let config_dir = args.path.clone().unwrap_or_else(|| PathBuf::from("."));
 
-    let config = Config::from_file(mail_dir.join("mujmap.toml")).context(OpenConfigFileSnafu {})?;
+    let config = Config::from_file(config_dir.join("mujmap.toml")).context(OpenConfigFileSnafu {})?;
     debug!("Using config: {:?}", config);
 
     match &args.command {
         args::Command::Sync => {
-            sync(stdout, info_color_spec, mail_dir, args, config).context(SyncSnafu {})
+            sync(stdout, info_color_spec, config_dir, args, config).context(SyncSnafu {})
         }
         args::Command::Send => todo!(),
     }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -199,12 +199,12 @@ impl LatestState {
 pub fn sync(
     stdout: &mut StandardStream,
     info_color_spec: ColorSpec,
-    mail_dir: PathBuf,
+    config_dir: PathBuf,
     args: Args,
     config: Config,
 ) -> Result<(), Error> {
     // Grab lock.
-    let lock_file_path = mail_dir.join("mujmap.lock");
+    let lock_file_path = config_dir.join("mujmap.lock");
     let mut lock = LockFile::open(&lock_file_path).context(OpenLockFileSnafu {
         path: lock_file_path,
     })?;
@@ -215,14 +215,14 @@ pub fn sync(
     }
 
     // Load the intermediary state.
-    let latest_state_filename = mail_dir.join("mujmap.state.json");
+    let latest_state_filename = config_dir.join("mujmap.state.json");
     let latest_state = LatestState::open(&latest_state_filename).unwrap_or_else(|e| {
         warn!("{e}");
         LatestState::empty()
     });
 
     // Open the local notmuch database.
-    let local = Local::open(mail_dir, args.dry_run).context(OpenLocalSnafu {})?;
+    let local = Local::open(args.dry_run).context(OpenLocalSnafu {})?;
 
     // Open the local cache.
     let cache = Cache::open(&local.mail_cur_dir, &config).context(OpenCacheSnafu {})?;


### PR DESCRIPTION
This makes mujmap work with notmuch's idea of the where the database and mail dirs are, allowing profiles, split config and XDG dirs to work.

Closes #25.