### PR TITLE
Use username domain for JMAP server discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Unix newlines for all newly downloaded mail files.
 - New configuration option `cache_dir` which changes the directory where mujmap
   downloads new files before adding them to the maildir.
+- By default, try to discover the JMAP server from the domain part of the
+  `username` configuration option. (#28)
 
 ### Changed
 - New mail files will have their line endings changed by default to Unix; see

--- a/mujmap.toml.example
+++ b/mujmap.toml.example
@@ -12,10 +12,11 @@ password_command = "pass example@fastmail.com"
 
 ## Fully qualified domain name of the JMAP service.
 ##
-## mujmap looks up the JMAP SRV record for this host to determine the JMAP
-## session URL. Mutually exclusive with `session_url`.
+## mujmap looks up the JMAP SRV record for the domain part of the username to
+## determine the JMAP session URL. Setting `fqdn` will cause it to use an
+## alternate name for that lookup.  Mutually exclusive with `session_url`.
 
-fqdn = "fastmail.com"
+# fqdn = "fastmail.com"
 
 ## Session URL to connect to.
 ##

--- a/src/config.rs
+++ b/src/config.rs
@@ -276,7 +276,7 @@ impl Config {
 
         // Perform final validation.
         ensure!(
-            config.fqdn.is_some() != config.session_url.is_some(),
+            !(config.fqdn.is_some() && config.session_url.is_some()),
             FqdnOrSessionUrlSnafu {}
         );
         ensure!(


### PR DESCRIPTION
RFC8621 suggests that clients could use the user domain for server
discovery, and at least one email provider automatically sets up the
correct SRV records for user domains.

So, if neither `fqdn` nor `session_url` are provided, try to use the
domain part for server lookup.