### PR TITLE
deps: bump notmuch-rs to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -814,8 +814,9 @@ dependencies = [
 
 [[package]]
 name = "notmuch"
-version = "0.7.2"
-source = "git+https://github.com/vhdirk/notmuch-rs#a24d8aa9715a47431610af9b3c88400d1896177f"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e25d11a2449f4f91cb71b138b241db30765a3b2f595eba0dd6a282b0e961dd44"
 dependencies = [
  "from_variants",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ itertools = "0.10.3"
 lazy_static = "1.4.0"
 loe = "0.3.0"
 log = "0.4.16"
-notmuch = { git = "https://github.com/vhdirk/notmuch-rs" }
+notmuch = "0.8.0"
 rayon = "1.5.2"
 regex = "1.5.5"
 serde = { version = "1.0.136", features = ["derive"] }


### PR DESCRIPTION
Gets the released version with support for getting at notmuch config.