### PR TITLE
Allow separate mail and state paths

### DIFF
--- a/mujmap.toml.example
+++ b/mujmap.toml.example
@@ -58,6 +58,16 @@ password_command = "pass example@fastmail.com"
 
 # cache_dir =
 
+## The location of the mail dir, where downloaded email is finally stored. If
+## not given, mujmap will try to figure out what you want. You probably don't
+## want to set this.
+
+# mail_dir =
+
+## The directory to store state files in. If not given, mujmap will try to
+## choose something # sensible. You probably don't want to set this.
+
+# state_dir =
 
 ################################################################################
 ## Tag config

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -53,8 +53,6 @@ pub struct Cache {
 
 impl Cache {
     /// Open the local store.
-    ///
-    /// `mail_dir` *must* be a subdirectory of the notmuch path.
     pub fn open(mail_cur_dir: impl AsRef<Path>, config: &Config) -> Result<Self> {
         let project_dirs = ProjectDirs::from("sh.eliza", "", "mujmap").unwrap();
         let default_cache_dir = project_dirs.cache_dir();

--- a/src/config.rs
+++ b/src/config.rs
@@ -2,7 +2,7 @@ use serde::Deserialize;
 use snafu::prelude::*;
 use std::{
     fs, io,
-    path::{Path, PathBuf},
+    path::PathBuf,
     process::{Command, ExitStatus},
     string::FromUtf8Error,
 };
@@ -90,6 +90,16 @@ pub struct Config {
     /// default is operating-system specific.
     #[serde(default = "Default::default")]
     pub cache_dir: Option<PathBuf>,
+
+    /// The location of the mail dir, where downloaded email is finally stored. If not given,
+    /// mujmap will try to figure out what you want. You probably don't want to set this.
+    #[serde(default = "Default::default")]
+    pub mail_dir: Option<PathBuf>,
+
+    /// The directory to store state files in. If not given, mujmap will try to choose something
+    /// sensible. You probably don't want to set this.
+    #[serde(default = "Default::default")]
+    pub state_dir: Option<PathBuf>,
 
     /// Customize the names and synchronization behaviors of notmuch tags with JMAP keywords and
     /// mailboxes.
@@ -266,13 +276,23 @@ fn default_convert_dos_to_unix() -> bool {
 }
 
 impl Config {
-    pub fn from_file(path: impl AsRef<Path>) -> Result<Self> {
-        let contents = fs::read_to_string(path.as_ref()).context(ReadConfigFileSnafu {
-            filename: path.as_ref(),
+    pub fn from_dir(path: &PathBuf) -> Result<Self> {
+        let filename = path.join("mujmap.toml");
+
+        let contents = fs::read_to_string(&filename).context(ReadConfigFileSnafu {
+            filename: filename.clone(),
         })?;
-        let config: Self = toml::from_str(contents.as_str()).context(ParseConfigFileSnafu {
-            filename: path.as_ref(),
+        let mut config: Self = toml::from_str(contents.as_str()).context(ParseConfigFileSnafu {
+            filename: filename.clone(),
         })?;
+
+        // In directory mode, if paths aren't offered then we use the config dir itself.
+        if config.mail_dir.is_none() {
+            config.mail_dir = Some(path.clone());
+        }
+        if config.state_dir.is_none() {
+            config.state_dir = Some(path.clone());
+        }
 
         // Perform final validation.
         ensure!(

--- a/src/config.rs
+++ b/src/config.rs
@@ -276,8 +276,12 @@ fn default_convert_dos_to_unix() -> bool {
 }
 
 impl Config {
-    pub fn from_dir(path: &PathBuf) -> Result<Self> {
-        let filename = path.join("mujmap.toml");
+    pub fn from_path(path: &PathBuf) -> Result<Self> {
+        let filename = if path.is_dir() {
+            path.join("mujmap.toml")
+        } else {
+            path.clone()
+        };
 
         let contents = fs::read_to_string(&filename).context(ReadConfigFileSnafu {
             filename: filename.clone(),
@@ -287,11 +291,13 @@ impl Config {
         })?;
 
         // In directory mode, if paths aren't offered then we use the config dir itself.
-        if config.mail_dir.is_none() {
-            config.mail_dir = Some(path.clone());
-        }
-        if config.state_dir.is_none() {
-            config.state_dir = Some(path.clone());
+        if path.is_dir() {
+            if config.mail_dir.is_none() {
+                config.mail_dir = Some(path.clone());
+            }
+            if config.state_dir.is_none() {
+                config.state_dir = Some(path.clone());
+            }
         }
 
         // Perform final validation.

--- a/src/local.rs
+++ b/src/local.rs
@@ -16,7 +16,6 @@ use std::collections::HashSet;
 use std::fs;
 use std::io;
 use std::path::PathBuf;
-use std::path::StripPrefixError;
 
 const ID_PATTERN: &'static str = r"[-A-Za-z0-9_]+";
 const MAIL_PATTERN: &'static str = formatcp!(r"^({})\.({})(?:$|:)", ID_PATTERN, ID_PATTERN);
@@ -34,17 +33,6 @@ lazy_static! {
 pub enum Error {
     #[snafu(display("Could not canonicalize given path: {}", source))]
     Canonicalize { source: io::Error },
-
-    #[snafu(display(
-        "Given maildir path `{}' is not a subdirectory of the notmuch root `{}'",
-        mail_dir.to_string_lossy(),
-        notmuch_root.to_string_lossy(),
-    ))]
-    MailDirNotASubdirOfNotmuchRoot {
-        mail_dir: PathBuf,
-        notmuch_root: PathBuf,
-        source: StripPrefixError,
-    },
 
     #[snafu(display("Could not open notmuch database: {}", source))]
     OpenDatabase { source: notmuch::Error },
@@ -110,28 +98,37 @@ impl Local {
         )
         .context(OpenDatabaseSnafu {})?;
 
-        // Get the relative directory of the maildir to the database path.
-        let canonical_db_path = db.path().canonicalize().context(CanonicalizeSnafu {})?;
-        let canonical_mail_dir_path = mail_dir
+        // Get notmuch's idea of the mail root. If, for whatever reason, we get nothing back for
+        // that key (ancient version of notmuch?), use the database path.
+        let mail_root = db
+            .config(ConfigKey::MailRoot)
+            .map_or(
+                db.path().into(),
+                |root| PathBuf::from(root)
+            )
             .canonicalize()
             .context(CanonicalizeSnafu {})?;
-        let relative_mail_dir = canonical_mail_dir_path
-            .strip_prefix(&canonical_db_path)
-            .context(MailDirNotASubdirOfNotmuchRootSnafu {
-                mail_dir: &canonical_mail_dir_path,
-                notmuch_root: &canonical_db_path,
-            })?;
 
-        // Build the query to search for all mail in our maildir.
-        let all_mail_query = format!("path:\"{}/**\"", relative_mail_dir.to_str().unwrap());
+        // Build the query to search for all mail in our maildir. If the maildir is under the
+        // notmuch mail root, then search under the relative maildir path (allowing multiple
+        // maildirs per notmuch dir). If not, assume this is the only maildir for the notmuch dir,
+        // and use a global query.
+        let all_mail_query = mail_dir
+            .strip_prefix(&mail_root)
+            .ok()
+            .filter(|rel| rel.components().count() > 0)
+            .map_or(
+                "path:**".to_string(),
+                |rel| format!("path:\"{}/**\"", rel.to_str().unwrap())
+            );
 
         // Ensure the maildir contains the standard cur, new, and tmp dirs.
-        let mail_cur_dir = canonical_mail_dir_path.join("cur");
+        let mail_cur_dir = mail_dir.join("cur");
         if !dry_run {
             for path in &[
                 &mail_cur_dir,
-                &canonical_mail_dir_path.join("new"),
-                &canonical_mail_dir_path.join("tmp"),
+                &mail_dir.join("new"),
+                &mail_dir.join("tmp"),
             ] {
                 fs::create_dir_all(path).context(CreateMaildirDirSnafu { path })?;
             }

--- a/src/local.rs
+++ b/src/local.rs
@@ -79,12 +79,6 @@ impl Local {
     /// Open the local store.
     pub fn open(config: &Config, dry_run: bool) -> Result<Self> {
 
-        let mail_dir = match &config.mail_dir {
-            Some(ref dir) => dir,
-            _ => todo!(),
-        }.canonicalize().context(CanonicalizeSnafu {})?;
-        debug!("mail dir: {}", mail_dir.to_string_lossy());
-
         // Open the notmuch database with default config options.
         let db = Database::open_with_config::<PathBuf, PathBuf>(
             None,
@@ -108,6 +102,14 @@ impl Local {
             )
             .canonicalize()
             .context(CanonicalizeSnafu {})?;
+
+        // Figure out our maildir. Either the configured thing, or notmuch's mail root. Which in
+        // the worst case will be notmuch's database dir, but that's probably not the worst choice.
+        let mail_dir = match &config.mail_dir {
+            Some(ref dir) => dir.clone(),
+            _             => mail_root.clone(),
+        }.canonicalize().context(CanonicalizeSnafu {})?;
+        debug!("mail dir: {}", mail_dir.to_string_lossy());
 
         // Build the query to search for all mail in our maildir. If the maildir is under the
         // notmuch mail root, then search under the relative maildir path (allowing multiple

--- a/src/local.rs
+++ b/src/local.rs
@@ -1,5 +1,6 @@
 use crate::jmap;
 use crate::sync::NewEmail;
+use crate::Config;
 use const_format::formatcp;
 use lazy_static::lazy_static;
 use log::debug;
@@ -14,7 +15,6 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 use std::fs;
 use std::io;
-use std::path::Path;
 use std::path::PathBuf;
 use std::path::StripPrefixError;
 
@@ -89,9 +89,14 @@ pub struct Local {
 
 impl Local {
     /// Open the local store.
-    ///
-    /// `mail_dir` *must* be a subdirectory of the notmuch path.
-    pub fn open(mail_dir: impl AsRef<Path>, dry_run: bool) -> Result<Self> {
+    pub fn open(config: &Config, dry_run: bool) -> Result<Self> {
+
+        let mail_dir = match &config.mail_dir {
+            Some(ref dir) => dir,
+            _ => todo!(),
+        }.canonicalize().context(CanonicalizeSnafu {})?;
+        debug!("mail dir: {}", mail_dir.to_string_lossy());
+
         // Open the notmuch database with default config options.
         let db = Database::open_with_config::<PathBuf, PathBuf>(
             None,
@@ -108,7 +113,6 @@ impl Local {
         // Get the relative directory of the maildir to the database path.
         let canonical_db_path = db.path().canonicalize().context(CanonicalizeSnafu {})?;
         let canonical_mail_dir_path = mail_dir
-            .as_ref()
             .canonicalize()
             .context(CanonicalizeSnafu {})?;
         let relative_mail_dir = canonical_mail_dir_path

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,9 +61,8 @@ fn try_main(stdout: &mut StandardStream) -> Result<(), Error> {
         .to_owned();
 
     // Determine working directory and load all data files.
-    let config_dir = args.path.clone().unwrap_or_else(|| PathBuf::from("."));
-
-    let config = Config::from_dir(&config_dir).context(OpenConfigFileSnafu {})?;
+    let config_path = args.path.clone().unwrap_or_else(|| PathBuf::from("."));
+    let config = Config::from_path(&config_path).context(OpenConfigFileSnafu {})?;
     debug!("Using config: {:?}", config);
 
     match args.command {

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,14 +61,14 @@ fn try_main(stdout: &mut StandardStream) -> Result<(), Error> {
         .to_owned();
 
     // Determine working directory and load all data files.
-    let mail_dir = args.path.clone().unwrap_or_else(|| PathBuf::from("."));
+    let config_dir = args.path.clone().unwrap_or_else(|| PathBuf::from("."));
 
-    let config = Config::from_file(mail_dir.join("mujmap.toml")).context(OpenConfigFileSnafu {})?;
+    let config = Config::from_dir(&config_dir).context(OpenConfigFileSnafu {})?;
     debug!("Using config: {:?}", config);
 
     match args.command {
         args::Command::Sync => {
-            sync(stdout, info_color_spec, mail_dir, args, config).context(SyncSnafu {})
+            sync(stdout, info_color_spec, args, config).context(SyncSnafu {})
         }
         args::Command::Send {
             read_recipients,

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -20,6 +20,9 @@ use termcolor::{ColorSpec, StandardStream, WriteColor};
 
 #[derive(Debug, Snafu)]
 pub enum Error {
+    #[snafu(display("Could not canonicalize given path: {}", source))]
+    Canonicalize { source: io::Error },
+
     #[snafu(display("Could not open lock file `{}': {}", path.to_string_lossy(), source))]
     OpenLockFile { path: PathBuf, source: io::Error },
 
@@ -199,12 +202,18 @@ impl LatestState {
 pub fn sync(
     stdout: &mut StandardStream,
     info_color_spec: ColorSpec,
-    mail_dir: PathBuf,
     args: Args,
     config: Config,
 ) -> Result<(), Error> {
+
+    let state_dir = match &config.state_dir {
+        Some(ref dir) => dir,
+        _ => todo!(),
+    }.canonicalize().context(CanonicalizeSnafu {})?;
+    debug!("state dir: {}", state_dir.to_string_lossy());
+
     // Grab lock.
-    let lock_file_path = mail_dir.join("mujmap.lock");
+    let lock_file_path = state_dir.join("mujmap.lock");
     let mut lock = LockFile::open(&lock_file_path).context(OpenLockFileSnafu {
         path: lock_file_path,
     })?;
@@ -215,14 +224,14 @@ pub fn sync(
     }
 
     // Load the intermediary state.
-    let latest_state_filename = mail_dir.join("mujmap.state.json");
+    let latest_state_filename = state_dir.join("mujmap.state.json");
     let latest_state = LatestState::open(&latest_state_filename).unwrap_or_else(|e| {
         warn!("{e}");
         LatestState::empty()
     });
 
     // Open the local notmuch database.
-    let local = Local::open(mail_dir, args.dry_run).context(OpenLocalSnafu {})?;
+    let local = Local::open(&config, args.dry_run).context(OpenLocalSnafu {})?;
 
     // Open the local cache.
     let cache = Cache::open(&local.mail_cur_dir, &config).context(OpenCacheSnafu {})?;

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -17,6 +17,7 @@ use std::io::{self, BufReader, BufWriter};
 use std::path::{Path, PathBuf};
 use symlink::symlink_file;
 use termcolor::{ColorSpec, StandardStream, WriteColor};
+use directories::ProjectDirs;
 
 #[derive(Debug, Snafu)]
 pub enum Error {
@@ -31,6 +32,12 @@ pub enum Error {
 
     #[snafu(display("Could not log string: {}", source))]
     Log { source: io::Error },
+
+    #[snafu(display("Could not create mujmap state dir `{}': {}", path.to_string_lossy(), source))]
+    CreateStateDir {
+        path: PathBuf,
+        source: io::Error,
+    },
 
     #[snafu(display("Could not read mujmap state file `{}': {}", filename.to_string_lossy(), source))]
     ReadStateFile {
@@ -207,10 +214,21 @@ pub fn sync(
 ) -> Result<(), Error> {
 
     let state_dir = match &config.state_dir {
-        Some(ref dir) => dir,
-        _ => todo!(),
-    }.canonicalize().context(CanonicalizeSnafu {})?;
+        Some(ref dir) => dir.clone(),
+        _ => {
+            let project_dirs = ProjectDirs::from("sh.eliza", "", "mujmap").unwrap();
+            project_dirs
+                .state_dir()
+                .unwrap_or_else(|| project_dirs.cache_dir())
+                .to_path_buf()
+        }
+    };
     debug!("state dir: {}", state_dir.to_string_lossy());
+
+    // Ensure the state dir exists.
+    fs::create_dir_all(&state_dir).context(CreateStateDirSnafu {
+        path: state_dir.clone(),
+    })?;
 
     // Grab lock.
     let lock_file_path = state_dir.join("mujmap.lock");


### PR DESCRIPTION
Add config items `mail_dir` and `state_dir` to allow these to be explicitly set in config, and modifies `--path` (`-C`) to set their defaults correctly depending on whether or not a directory or a file is offered:

* directory: config file is `mujmap.toml` in the given dir, `mail_dir` and `state_dir` default to the given dir (that is, same as existing behaviour)
* file: config file is as given, `mail_dir` defaults to notmuch's `mail_root`, `state_dir` defaults to the system-standard state/cache dir.

This covers points (1) and (2) in my [comment on #29](https://github.com/elizagamedev/mujmap/issues/29#issuecomment-1148312024) and sets a base for (3).