### PR TITLE
Add support for HTTP Bearer authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Support for bearer token authentication (#40)
+
 ### Changed
 - mujmap now prints a more comprehensive guide on how to recover from a missing
   state file. (#15)

--- a/mujmap.toml.example
+++ b/mujmap.toml.example
@@ -1,12 +1,13 @@
 ################################################################################
 ## Required config
 
-## Username for basic HTTP authentication.
+## Account username. Used for authentication to the server.
 
 username = "example@fastmail.com"
 
-## Shell command which will print a password to stdout for basic HTTP
-## authentication.
+## Shell command which will print a password or token to stdout for
+## authentication. You service provider might call this an "app password" or
+## "API token".
 
 password_command = "pass example@fastmail.com"
 


### PR DESCRIPTION
Reorganises the auth and session setup code to support multiple auth schemes and server discovery of available schemes, and then adds Bearer support in addition to Basic.

When Bearer is selected, it just uses the configured password command as the token as normal. I thought about making this a separate config option but I'm not sure there's a lot of point really. If I was starting fresh maybe I'd call it `credential_command` but eh.

Closes #39.