### PR TITLE
config: trim whitespace from password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - mujmap now prints a more comprehensive guide on how to recover from a missing
   state file. (#15)
+- Leading and trailing whitespace (including newlines) is now removed from the
+  password returned by `password_command`. (#41)
 
 ## [0.2.0] - 2022-06-06
 ### Added

--- a/src/config.rs
+++ b/src/config.rs
@@ -305,6 +305,6 @@ impl Config {
             }
         );
         let stdout = String::from_utf8(output.stdout).context(DecodePasswordCommandSnafu {})?;
-        Ok(stdout)
+        Ok(stdout.trim().to_string())
     }
 }


### PR DESCRIPTION
The password command will often emit a trailing newline, which mujmap
was including in the password sent on the wire. Basic auth users base64,
which is sort of lenient about newlines, but other auth schemes are not
quite as forgiving.

Removing all trailing and leading whitespace is possibly too aggressive,
as it will break passwords that have legitimate whitespace in those
positions. On the other hand, its easy to do this way and such a
password seems bananas, so I'll take the risk for now.