### PR TITLE
WIP: Look up message in notmuch instead of using heavy query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -358,6 +358,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "file-matcher"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d54a429ce9698e7d0de61e7f570477cc2d2f8b3f48f976b2edcfdbd797c085eb"
+dependencies = [
+ "fs_extra",
+ "regex",
+ "serde",
+ "wildmatch",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -411,6 +423,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2022715d62ab30faffd124d40b76f4134a550a87792276512b18d63272333394"
 
 [[package]]
 name = "fslock"
@@ -718,6 +736,7 @@ dependencies = [
  "either",
  "email-parser",
  "env_logger",
+ "file-matcher",
  "fqdn",
  "fslock",
  "indicatif",
@@ -1479,6 +1498,12 @@ name = "widestring"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17882f045410753661207383517a6f62ec3dbeb6a4ed2acce01f0728238d1983"
+
+[[package]]
+name = "wildmatch"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee583bdc5ff1cf9db20e9db5bb3ff4c3089a8f6b8b31aff265c9aba85812db86"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,4 @@ toml = "0.5.9"
 trust-dns-resolver = "0.21.2"
 ureq = { version = "2.4.0", features = ["json"] }
 uritemplate-next = "0.2.0"
+file-matcher = "0.7.0"


### PR DESCRIPTION
Attempts to address #31.

So far this is pretty sloppy but it's the best I've been able to figure out with my limited knowledge of rust and types. In general, the approach is to look up the message in notmuch in each case rather than loading all messages in and looking up in that array.

So far I've been able to defer the heavy query in most cases but I'm stuck and could use some help cleaning this up. I've fallen back to having `email_exists_from_id` just return a bool since that's all I can wrap my head around. But later in the sync process, we actually need to get the message from the id.

I've found `self.emails_from_message()` which does what I need but I'm stuck trying to return a message type. With that in place, I could go back and reimplement the `local_email.blob_id != remote_email.blob_id` check.

In general, this seems to perform substantially faster and I'm close to completely removing the heavy `local.all_emails()` query but could use some help getting past a few hurdles.