### PR TITLE
Add `x86_64-darwin` to flake outputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -7,7 +7,7 @@
   };
 
   outputs = { self, nixpkgs, flake-utils, cargo2nix }:
-    flake-utils.lib.eachSystem [ "x86_64-linux" ] (system:
+    flake-utils.lib.eachSystem [ "x86_64-linux" "x86_64-darwin" ] (system:
       let
         pkgs = import nixpkgs {
           inherit system;
@@ -23,7 +23,7 @@
           mujmap = ((rustPkgs.workspace.mujmap {}).overrideAttrs(oa: {
             propagatedBuildInputs = oa.propagatedBuildInputs ++ [ pkgs.notmuch ];
           })).bin;
-          
+
           default = mujmap;
         };
       });


### PR DESCRIPTION
hi! i had to add this in order to be able to import and use the flake on my intel mac.